### PR TITLE
Change pointer type to move and crosshair

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -112,8 +112,6 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.4",
-        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
-        "chokidar": "^3.4.0",
         "commander": "^4.0.1",
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
@@ -2446,7 +2444,6 @@
       "dependencies": {
         "anymatch": "^1.3.0",
         "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
         "glob-parent": "^2.0.0",
         "inherits": "^2.0.1",
         "is-binary-path": "^1.0.0",
@@ -4390,7 +4387,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -5711,8 +5707,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -10271,7 +10266,6 @@
     },
     "node_modules/nyc/node_modules/align-text": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10287,7 +10281,6 @@
     },
     "node_modules/nyc/node_modules/amdefine": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause OR MIT",
@@ -10297,7 +10290,6 @@
     },
     "node_modules/nyc/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10307,7 +10299,6 @@
     },
     "node_modules/nyc/node_modules/ansi-styles": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10317,7 +10308,6 @@
     },
     "node_modules/nyc/node_modules/append-transform": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10330,14 +10320,12 @@
     },
     "node_modules/nyc/node_modules/archy": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/nyc/node_modules/arr-diff": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10350,7 +10338,6 @@
     },
     "node_modules/nyc/node_modules/arr-flatten": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10360,7 +10347,6 @@
     },
     "node_modules/nyc/node_modules/array-unique": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10370,7 +10356,6 @@
     },
     "node_modules/nyc/node_modules/arrify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10380,14 +10365,12 @@
     },
     "node_modules/nyc/node_modules/async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/nyc/node_modules/babel-code-frame": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10399,7 +10382,6 @@
     },
     "node_modules/nyc/node_modules/babel-generator": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10416,7 +10398,6 @@
     },
     "node_modules/nyc/node_modules/babel-messages": {
       "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10426,7 +10407,6 @@
     },
     "node_modules/nyc/node_modules/babel-runtime": {
       "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10437,7 +10417,6 @@
     },
     "node_modules/nyc/node_modules/babel-template": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10451,7 +10430,6 @@
     },
     "node_modules/nyc/node_modules/babel-traverse": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10469,7 +10447,6 @@
     },
     "node_modules/nyc/node_modules/babel-types": {
       "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10482,7 +10459,6 @@
     },
     "node_modules/nyc/node_modules/babylon": {
       "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10492,14 +10468,12 @@
     },
     "node_modules/nyc/node_modules/balanced-match": {
       "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/nyc/node_modules/brace-expansion": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10510,7 +10484,6 @@
     },
     "node_modules/nyc/node_modules/braces": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10525,7 +10498,6 @@
     },
     "node_modules/nyc/node_modules/builtin-modules": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10535,7 +10507,6 @@
     },
     "node_modules/nyc/node_modules/caching-transform": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10550,7 +10521,6 @@
     },
     "node_modules/nyc/node_modules/camelcase": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10561,7 +10531,6 @@
     },
     "node_modules/nyc/node_modules/center-align": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10576,7 +10545,6 @@
     },
     "node_modules/nyc/node_modules/chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10593,7 +10561,6 @@
     },
     "node_modules/nyc/node_modules/cliui": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10606,7 +10573,6 @@
     },
     "node_modules/nyc/node_modules/cliui/node_modules/wordwrap": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT/X11",
@@ -10617,7 +10583,6 @@
     },
     "node_modules/nyc/node_modules/code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10627,35 +10592,30 @@
     },
     "node_modules/nyc/node_modules/commondir": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/nyc/node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/nyc/node_modules/convert-source-map": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/nyc/node_modules/core-js": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/nyc/node_modules/cross-spawn": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10666,7 +10626,6 @@
     },
     "node_modules/nyc/node_modules/debug": {
       "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.6.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10676,7 +10635,6 @@
     },
     "node_modules/nyc/node_modules/debug-log": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10686,7 +10644,6 @@
     },
     "node_modules/nyc/node_modules/decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10696,7 +10653,6 @@
     },
     "node_modules/nyc/node_modules/default-require-extensions": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10709,7 +10665,6 @@
     },
     "node_modules/nyc/node_modules/detect-indent": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10722,7 +10677,6 @@
     },
     "node_modules/nyc/node_modules/error-ex": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10732,7 +10686,6 @@
     },
     "node_modules/nyc/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10742,7 +10695,6 @@
     },
     "node_modules/nyc/node_modules/esutils": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "dev": true,
       "inBundle": true,
       "engines": {
@@ -10751,7 +10703,6 @@
     },
     "node_modules/nyc/node_modules/expand-brackets": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10764,7 +10715,6 @@
     },
     "node_modules/nyc/node_modules/expand-range": {
       "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10777,7 +10727,6 @@
     },
     "node_modules/nyc/node_modules/extglob": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10790,7 +10739,6 @@
     },
     "node_modules/nyc/node_modules/filename-regex": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10800,7 +10748,6 @@
     },
     "node_modules/nyc/node_modules/fill-range": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10817,7 +10764,6 @@
     },
     "node_modules/nyc/node_modules/find-cache-dir": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10832,7 +10778,6 @@
     },
     "node_modules/nyc/node_modules/find-up": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10846,7 +10791,6 @@
     },
     "node_modules/nyc/node_modules/for-in": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10856,7 +10800,6 @@
     },
     "node_modules/nyc/node_modules/for-own": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10869,7 +10812,6 @@
     },
     "node_modules/nyc/node_modules/foreground-child": {
       "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10880,21 +10822,18 @@
     },
     "node_modules/nyc/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/nyc/node_modules/get-caller-file": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/nyc/node_modules/glob": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10912,7 +10851,6 @@
     },
     "node_modules/nyc/node_modules/glob-base": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10926,7 +10864,6 @@
     },
     "node_modules/nyc/node_modules/glob-parent": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10936,7 +10873,6 @@
     },
     "node_modules/nyc/node_modules/globals": {
       "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10946,7 +10882,6 @@
     },
     "node_modules/nyc/node_modules/graceful-fs": {
       "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10956,15 +10891,13 @@
     },
     "node_modules/nyc/node_modules/handlebars": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.8.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "async": "^1.4.0",
         "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "source-map": "^0.4.4"
       },
       "bin": {
         "handlebars": "bin/handlebars"
@@ -10978,7 +10911,6 @@
     },
     "node_modules/nyc/node_modules/handlebars/node_modules/source-map": {
       "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -10991,7 +10923,6 @@
     },
     "node_modules/nyc/node_modules/has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11004,7 +10935,6 @@
     },
     "node_modules/nyc/node_modules/has-flag": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11014,14 +10944,12 @@
     },
     "node_modules/nyc/node_modules/hosted-git-info": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/nyc/node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11031,7 +10959,6 @@
     },
     "node_modules/nyc/node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11042,14 +10969,12 @@
     },
     "node_modules/nyc/node_modules/inherits": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/nyc/node_modules/invariant": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -11059,7 +10984,6 @@
     },
     "node_modules/nyc/node_modules/invert-kv": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11069,21 +10993,18 @@
     },
     "node_modules/nyc/node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/nyc/node_modules/is-buffer": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/nyc/node_modules/is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11096,7 +11017,6 @@
     },
     "node_modules/nyc/node_modules/is-dotfile": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11106,7 +11026,6 @@
     },
     "node_modules/nyc/node_modules/is-equal-shallow": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11119,7 +11038,6 @@
     },
     "node_modules/nyc/node_modules/is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11129,7 +11047,6 @@
     },
     "node_modules/nyc/node_modules/is-extglob": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11139,7 +11056,6 @@
     },
     "node_modules/nyc/node_modules/is-finite": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11152,7 +11068,6 @@
     },
     "node_modules/nyc/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11165,7 +11080,6 @@
     },
     "node_modules/nyc/node_modules/is-glob": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11178,7 +11092,6 @@
     },
     "node_modules/nyc/node_modules/is-number": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11191,7 +11104,6 @@
     },
     "node_modules/nyc/node_modules/is-posix-bracket": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11201,7 +11113,6 @@
     },
     "node_modules/nyc/node_modules/is-primitive": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11211,28 +11122,24 @@
     },
     "node_modules/nyc/node_modules/is-utf8": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/nyc/node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/nyc/node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/nyc/node_modules/isobject": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11245,14 +11152,12 @@
     },
     "node_modules/nyc/node_modules/istanbul-lib-coverage": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/nyc/node_modules/istanbul-lib-hook": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.6.tgz",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -11262,7 +11167,6 @@
     },
     "node_modules/nyc/node_modules/istanbul-lib-instrument": {
       "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -11278,7 +11182,6 @@
     },
     "node_modules/nyc/node_modules/istanbul-lib-report": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -11291,7 +11194,6 @@
     },
     "node_modules/nyc/node_modules/istanbul-lib-report/node_modules/supports-color": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11304,7 +11206,6 @@
     },
     "node_modules/nyc/node_modules/istanbul-lib-source-maps": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -11318,7 +11219,6 @@
     },
     "node_modules/nyc/node_modules/istanbul-reports": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -11328,14 +11228,12 @@
     },
     "node_modules/nyc/node_modules/js-tokens": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/nyc/node_modules/jsesc": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11345,7 +11243,6 @@
     },
     "node_modules/nyc/node_modules/kind-of": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11358,7 +11255,6 @@
     },
     "node_modules/nyc/node_modules/lazy-cache": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11369,7 +11265,6 @@
     },
     "node_modules/nyc/node_modules/lcid": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11382,7 +11277,6 @@
     },
     "node_modules/nyc/node_modules/load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11399,14 +11293,12 @@
     },
     "node_modules/nyc/node_modules/lodash": {
       "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/nyc/node_modules/longest": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11417,7 +11309,6 @@
     },
     "node_modules/nyc/node_modules/loose-envify": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11430,7 +11321,6 @@
     },
     "node_modules/nyc/node_modules/lru-cache": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11441,7 +11331,6 @@
     },
     "node_modules/nyc/node_modules/md5-hex": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11454,13 +11343,11 @@
     },
     "node_modules/nyc/node_modules/md5-o-matic": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
       "dev": true,
       "inBundle": true
     },
     "node_modules/nyc/node_modules/merge-source-map": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.3.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11470,7 +11357,6 @@
     },
     "node_modules/nyc/node_modules/micromatch": {
       "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11495,7 +11381,6 @@
     },
     "node_modules/nyc/node_modules/minimatch": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11508,14 +11393,12 @@
     },
     "node_modules/nyc/node_modules/minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/nyc/node_modules/mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11528,14 +11411,12 @@
     },
     "node_modules/nyc/node_modules/ms": {
       "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/nyc/node_modules/normalize-package-data": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -11548,7 +11429,6 @@
     },
     "node_modules/nyc/node_modules/normalize-path": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11561,7 +11441,6 @@
     },
     "node_modules/nyc/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11571,7 +11450,6 @@
     },
     "node_modules/nyc/node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11581,7 +11459,6 @@
     },
     "node_modules/nyc/node_modules/object.omit": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11595,7 +11472,6 @@
     },
     "node_modules/nyc/node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11605,7 +11481,6 @@
     },
     "node_modules/nyc/node_modules/optimist": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT/X11",
@@ -11616,7 +11491,6 @@
     },
     "node_modules/nyc/node_modules/os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11626,7 +11500,6 @@
     },
     "node_modules/nyc/node_modules/os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11639,7 +11512,6 @@
     },
     "node_modules/nyc/node_modules/parse-glob": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11655,7 +11527,6 @@
     },
     "node_modules/nyc/node_modules/parse-json": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11668,7 +11539,6 @@
     },
     "node_modules/nyc/node_modules/path-exists": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11681,7 +11551,6 @@
     },
     "node_modules/nyc/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11691,14 +11560,12 @@
     },
     "node_modules/nyc/node_modules/path-parse": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/nyc/node_modules/path-type": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11713,7 +11580,6 @@
     },
     "node_modules/nyc/node_modules/pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11723,7 +11589,6 @@
     },
     "node_modules/nyc/node_modules/pinkie": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11733,7 +11598,6 @@
     },
     "node_modules/nyc/node_modules/pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11746,7 +11610,6 @@
     },
     "node_modules/nyc/node_modules/pkg-dir": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11759,7 +11622,6 @@
     },
     "node_modules/nyc/node_modules/preserve": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11769,14 +11631,12 @@
     },
     "node_modules/nyc/node_modules/pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/nyc/node_modules/randomatic": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11790,7 +11650,6 @@
     },
     "node_modules/nyc/node_modules/read-pkg": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11805,7 +11664,6 @@
     },
     "node_modules/nyc/node_modules/read-pkg-up": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11819,14 +11677,12 @@
     },
     "node_modules/nyc/node_modules/regenerator-runtime": {
       "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/nyc/node_modules/regex-cache": {
       "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11840,14 +11696,12 @@
     },
     "node_modules/nyc/node_modules/remove-trailing-separator": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/nyc/node_modules/repeat-element": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11857,7 +11711,6 @@
     },
     "node_modules/nyc/node_modules/repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11867,7 +11720,6 @@
     },
     "node_modules/nyc/node_modules/repeating": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11880,7 +11732,6 @@
     },
     "node_modules/nyc/node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11890,14 +11741,12 @@
     },
     "node_modules/nyc/node_modules/require-main-filename": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/nyc/node_modules/resolve-from": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11907,7 +11756,6 @@
     },
     "node_modules/nyc/node_modules/right-align": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11921,7 +11769,6 @@
     },
     "node_modules/nyc/node_modules/rimraf": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11934,7 +11781,6 @@
     },
     "node_modules/nyc/node_modules/semver": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11944,21 +11790,18 @@
     },
     "node_modules/nyc/node_modules/set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/nyc/node_modules/signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/nyc/node_modules/slide": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11968,7 +11811,6 @@
     },
     "node_modules/nyc/node_modules/source-map": {
       "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -11978,7 +11820,6 @@
     },
     "node_modules/nyc/node_modules/spawn-wrap": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.2.4.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11993,14 +11834,12 @@
     },
     "node_modules/nyc/node_modules/spawn-wrap/node_modules/signal-exit": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/nyc/node_modules/spdx-correct": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -12010,21 +11849,18 @@
     },
     "node_modules/nyc/node_modules/spdx-expression-parse": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
       "dev": true,
       "inBundle": true,
       "license": "(MIT AND CC-BY-3.0)"
     },
     "node_modules/nyc/node_modules/spdx-license-ids": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "Unlicense"
     },
     "node_modules/nyc/node_modules/string-width": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12039,7 +11875,6 @@
     },
     "node_modules/nyc/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12052,7 +11887,6 @@
     },
     "node_modules/nyc/node_modules/strip-bom": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12065,7 +11899,6 @@
     },
     "node_modules/nyc/node_modules/supports-color": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12075,7 +11908,6 @@
     },
     "node_modules/nyc/node_modules/test-exclude": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12089,7 +11921,6 @@
     },
     "node_modules/nyc/node_modules/to-fast-properties": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12099,7 +11930,6 @@
     },
     "node_modules/nyc/node_modules/trim-right": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12109,14 +11939,12 @@
     },
     "node_modules/nyc/node_modules/uglify-js": {
       "version": "2.8.22",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "dependencies": {
         "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
         "yargs": "~3.10.0"
       },
       "bin": {
@@ -12131,7 +11959,6 @@
     },
     "node_modules/nyc/node_modules/uglify-js/node_modules/yargs": {
       "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12145,7 +11972,6 @@
     },
     "node_modules/nyc/node_modules/uglify-to-browserify": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12153,7 +11979,6 @@
     },
     "node_modules/nyc/node_modules/validate-npm-package-license": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -12164,7 +11989,6 @@
     },
     "node_modules/nyc/node_modules/which": {
       "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12177,14 +12001,12 @@
     },
     "node_modules/nyc/node_modules/which-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/nyc/node_modules/window-size": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "dev": true,
       "inBundle": true,
       "optional": true,
@@ -12194,7 +12016,6 @@
     },
     "node_modules/nyc/node_modules/wordwrap": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12204,7 +12025,6 @@
     },
     "node_modules/nyc/node_modules/wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12218,14 +12038,12 @@
     },
     "node_modules/nyc/node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/nyc/node_modules/write-file-atomic": {
       "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12237,21 +12055,18 @@
     },
     "node_modules/nyc/node_modules/y18n": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/nyc/node_modules/yallist": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/nyc/node_modules/yargs": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12273,7 +12088,6 @@
     },
     "node_modules/nyc/node_modules/yargs-parser": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12283,7 +12097,6 @@
     },
     "node_modules/nyc/node_modules/yargs-parser/node_modules/camelcase": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12293,7 +12106,6 @@
     },
     "node_modules/nyc/node_modules/yargs/node_modules/camelcase": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -12303,7 +12115,6 @@
     },
     "node_modules/nyc/node_modules/yargs/node_modules/cliui": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -12590,12 +12401,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/openseadragon": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/openseadragon/-/openseadragon-2.4.2.tgz",
-      "integrity": "sha512-398KbZwRtOYA6OmeWRY4Q0737NTacQ9Q6whmr9Lp1MNQO3p0eBz5LIASRne+4gwequcSM1vcHcjfy3dIndQziw==",
-      "peer": true
     },
     "node_modules/opn": {
       "version": "5.5.0",
@@ -15529,19 +15334,6 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/ua-parser-js": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
@@ -15567,7 +15359,6 @@
       "dev": true,
       "dependencies": {
         "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
         "yargs": "~3.10.0"
       },
       "bin": {
@@ -16078,10 +15869,8 @@
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dev": true,
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.1"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -16165,7 +15954,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -16526,7 +16314,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -18620,8 +18407,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "align-text": {
       "version": "0.1.4",
@@ -25460,7 +25246,6 @@
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25472,25 +25257,21 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
           "bundled": true,
           "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "bundled": true,
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "bundled": true,
           "dev": true
         },
         "append-transform": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25499,13 +25280,11 @@
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
           "bundled": true,
           "dev": true
         },
         "arr-diff": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25514,31 +25293,26 @@
         },
         "arr-flatten": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
           "bundled": true,
           "dev": true
         },
         "array-unique": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
           "bundled": true,
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
           "bundled": true,
           "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "bundled": true,
           "dev": true
         },
         "babel-code-frame": {
           "version": "6.22.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25549,7 +25323,6 @@
         },
         "babel-generator": {
           "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25565,7 +25338,6 @@
         },
         "babel-messages": {
           "version": "6.23.0",
-          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25574,7 +25346,6 @@
         },
         "babel-runtime": {
           "version": "6.23.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25584,7 +25355,6 @@
         },
         "babel-template": {
           "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25597,7 +25367,6 @@
         },
         "babel-traverse": {
           "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25614,7 +25383,6 @@
         },
         "babel-types": {
           "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25626,19 +25394,16 @@
         },
         "babylon": {
           "version": "6.17.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
           "bundled": true,
           "dev": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
           "bundled": true,
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25648,7 +25413,6 @@
         },
         "braces": {
           "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25659,13 +25423,11 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
           "bundled": true,
           "dev": true
         },
         "caching-transform": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25676,14 +25438,12 @@
         },
         "camelcase": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25694,7 +25454,6 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25707,7 +25466,6 @@
         },
         "cliui": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25719,7 +25477,6 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
               "bundled": true,
               "dev": true,
               "optional": true
@@ -25728,37 +25485,31 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "bundled": true,
           "dev": true
         },
         "commondir": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
           "bundled": true,
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "bundled": true,
           "dev": true
         },
         "convert-source-map": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
           "bundled": true,
           "dev": true
         },
         "core-js": {
           "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
           "bundled": true,
           "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25768,7 +25519,6 @@
         },
         "debug": {
           "version": "2.6.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.6.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25777,19 +25527,16 @@
         },
         "debug-log": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
           "bundled": true,
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "bundled": true,
           "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25798,7 +25545,6 @@
         },
         "detect-indent": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25807,7 +25553,6 @@
         },
         "error-ex": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25816,19 +25561,16 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "bundled": true,
           "dev": true
         },
         "esutils": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
           "bundled": true,
           "dev": true
         },
         "expand-brackets": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25837,7 +25579,6 @@
         },
         "expand-range": {
           "version": "1.8.2",
-          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25846,7 +25587,6 @@
         },
         "extglob": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25855,13 +25595,11 @@
         },
         "filename-regex": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
           "bundled": true,
           "dev": true
         },
         "fill-range": {
           "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25874,7 +25612,6 @@
         },
         "find-cache-dir": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25885,7 +25622,6 @@
         },
         "find-up": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25895,13 +25631,11 @@
         },
         "for-in": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "bundled": true,
           "dev": true
         },
         "for-own": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25910,7 +25644,6 @@
         },
         "foreground-child": {
           "version": "1.5.6",
-          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25920,19 +25653,16 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "bundled": true,
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
           "bundled": true,
           "dev": true
         },
         "glob": {
           "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25946,7 +25676,6 @@
         },
         "glob-base": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25956,7 +25685,6 @@
         },
         "glob-parent": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25965,19 +25693,16 @@
         },
         "globals": {
           "version": "9.17.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
           "bundled": true,
           "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "bundled": true,
           "dev": true
         },
         "handlebars": {
           "version": "4.0.8",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.8.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -25989,7 +25714,6 @@
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -26000,7 +25724,6 @@
         },
         "has-ansi": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26009,25 +25732,21 @@
         },
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "bundled": true,
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
           "bundled": true,
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "bundled": true,
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26037,13 +25756,11 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "bundled": true,
           "dev": true
         },
         "invariant": {
           "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26052,25 +25769,21 @@
         },
         "invert-kv": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
           "bundled": true,
           "dev": true
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
           "bundled": true,
           "dev": true
         },
         "is-buffer": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
           "bundled": true,
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26079,13 +25792,11 @@
         },
         "is-dotfile": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
           "bundled": true,
           "dev": true
         },
         "is-equal-shallow": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26094,19 +25805,16 @@
         },
         "is-extendable": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
           "bundled": true,
           "dev": true
         },
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "bundled": true,
           "dev": true
         },
         "is-finite": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26115,7 +25823,6 @@
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26124,7 +25831,6 @@
         },
         "is-glob": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26133,7 +25839,6 @@
         },
         "is-number": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26142,37 +25847,31 @@
         },
         "is-posix-bracket": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
           "bundled": true,
           "dev": true
         },
         "is-primitive": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
           "bundled": true,
           "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
           "bundled": true,
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "bundled": true,
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
           "bundled": true,
           "dev": true
         },
         "isobject": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26181,13 +25880,11 @@
         },
         "istanbul-lib-coverage": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
           "bundled": true,
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.6.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26196,7 +25893,6 @@
         },
         "istanbul-lib-instrument": {
           "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26211,7 +25907,6 @@
         },
         "istanbul-lib-report": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26223,7 +25918,6 @@
           "dependencies": {
             "supports-color": {
               "version": "3.2.3",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -26234,7 +25928,6 @@
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26247,7 +25940,6 @@
         },
         "istanbul-reports": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26256,19 +25948,16 @@
         },
         "js-tokens": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
           "bundled": true,
           "dev": true
         },
         "jsesc": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
           "bundled": true,
           "dev": true
         },
         "kind-of": {
           "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26277,14 +25966,12 @@
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26293,7 +25980,6 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26306,20 +25992,17 @@
         },
         "lodash": {
           "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "bundled": true,
           "dev": true
         },
         "longest": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26328,7 +26011,6 @@
         },
         "lru-cache": {
           "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26338,7 +26020,6 @@
         },
         "md5-hex": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26347,13 +26028,11 @@
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
           "bundled": true,
           "dev": true
         },
         "merge-source-map": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.3.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26362,7 +26041,6 @@
         },
         "micromatch": {
           "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26383,7 +26061,6 @@
         },
         "minimatch": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26392,13 +26069,11 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "bundled": true,
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26407,13 +26082,11 @@
         },
         "ms": {
           "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
           "bundled": true,
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26425,7 +26098,6 @@
         },
         "normalize-path": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26434,19 +26106,16 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "bundled": true,
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "bundled": true,
           "dev": true
         },
         "object.omit": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26456,7 +26125,6 @@
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26465,7 +26133,6 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26475,13 +26142,11 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "bundled": true,
           "dev": true
         },
         "os-locale": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26490,7 +26155,6 @@
         },
         "parse-glob": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26502,7 +26166,6 @@
         },
         "parse-json": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26511,7 +26174,6 @@
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26520,19 +26182,16 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "bundled": true,
           "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
           "bundled": true,
           "dev": true
         },
         "path-type": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26543,19 +26202,16 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "bundled": true,
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "bundled": true,
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26564,7 +26220,6 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26573,19 +26228,16 @@
         },
         "preserve": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
           "bundled": true,
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
           "bundled": true,
           "dev": true
         },
         "randomatic": {
           "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26595,7 +26247,6 @@
         },
         "read-pkg": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26606,7 +26257,6 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26616,13 +26266,11 @@
         },
         "regenerator-runtime": {
           "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "bundled": true,
           "dev": true
         },
         "regex-cache": {
           "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26632,25 +26280,21 @@
         },
         "remove-trailing-separator": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
           "bundled": true,
           "dev": true
         },
         "repeat-element": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
           "bundled": true,
           "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "bundled": true,
           "dev": true
         },
         "repeating": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26659,25 +26303,21 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
           "bundled": true,
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
           "bundled": true,
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
           "bundled": true,
           "dev": true
         },
         "right-align": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26687,7 +26327,6 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26696,37 +26335,31 @@
         },
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "bundled": true,
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "bundled": true,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "bundled": true,
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
           "bundled": true,
           "dev": true
         },
         "source-map": {
           "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "bundled": true,
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.2.4.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26740,7 +26373,6 @@
           "dependencies": {
             "signal-exit": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
               "bundled": true,
               "dev": true
             }
@@ -26748,7 +26380,6 @@
         },
         "spdx-correct": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26757,19 +26388,16 @@
         },
         "spdx-expression-parse": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
           "bundled": true,
           "dev": true
         },
         "spdx-license-ids": {
           "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
           "bundled": true,
           "dev": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26780,7 +26408,6 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26789,7 +26416,6 @@
         },
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26798,13 +26424,11 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "bundled": true,
           "dev": true
         },
         "test-exclude": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26817,19 +26441,16 @@
         },
         "to-fast-properties": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
           "bundled": true,
           "dev": true
         },
         "trim-right": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
           "bundled": true,
           "dev": true
         },
         "uglify-js": {
           "version": "2.8.22",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -26841,7 +26462,6 @@
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "bundled": true,
               "dev": true,
               "optional": true,
@@ -26856,14 +26476,12 @@
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26873,7 +26491,6 @@
         },
         "which": {
           "version": "1.2.14",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26882,26 +26499,22 @@
         },
         "which-module": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
           "bundled": true,
           "dev": true
         },
         "window-size": {
           "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "bundled": true,
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26911,13 +26524,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26928,19 +26539,16 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
           "bundled": true,
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "bundled": true,
           "dev": true
         },
         "yargs": {
           "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26961,13 +26569,11 @@
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
               "bundled": true,
               "dev": true
             },
             "cliui": {
               "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -26980,7 +26586,6 @@
         },
         "yargs-parser": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -26989,7 +26594,6 @@
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
               "bundled": true,
               "dev": true
             }
@@ -27205,12 +26809,6 @@
       "requires": {
         "mimic-fn": "^1.0.0"
       }
-    },
-    "openseadragon": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/openseadragon/-/openseadragon-2.4.2.tgz",
-      "integrity": "sha512-398KbZwRtOYA6OmeWRY4Q0737NTacQ9Q6whmr9Lp1MNQO3p0eBz5LIASRne+4gwequcSM1vcHcjfy3dIndQziw==",
-      "peer": true
     },
     "opn": {
       "version": "5.5.0",
@@ -29291,8 +28889,7 @@
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
           "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
@@ -29616,12 +29213,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
-    "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
     "ua-parser-js": {

--- a/src/views/Overlay.js
+++ b/src/views/Overlay.js
@@ -101,7 +101,7 @@ class Overlay extends Component {
         height: '100%',
         id: this.props.name,
         style: {
-          cursor: 'default',
+          cursor: (this.state.mode === 'MOVE' ? 'move' : 'crosshair'),
           'background-color': 'rgba(0,0,0,0)', // IE 9-10 fix
         },
         onMouseDown,


### PR DESCRIPTION
Render SVG layer's pointer as either move or crosshair depending on annotation mode. 

Change was made in this repo instead of from the front-end as the SVG layer described in `Overlay.js` re-renders upon mouse events. In the file, these are any changes that affect it's `state` or `props`. 
The engine uses preact, and the front-end would have a hard time keeping track of a dependency's re-renders. 